### PR TITLE
Added hibertantion support for channels

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,8 @@ vNEXT | xx xxx xxxx
   * Add support for handling of 301/302 HTTP redirects
   * Add support for detecting encrypted input and switching sources
     if the input is encrypted (use -E option).
+  * Add support to hibernate channels. The web interface has support
+    for start/stop commands. Channels can start in hibernation.
 
 v1.30 | 21 Dec 2016
   * Add web access for monitoring and reconfiguration

--- a/README.WEB_ACCESS
+++ b/README.WEB_ACCESS
@@ -26,16 +26,28 @@ The following endpoints are accessible:
   Reload config file. This would start/stop new/removed channels.
 
 
+    http://127.0.0.1:8081/stop/chan1
+
+  Hibernates the channel "chan1". If it's already paused,
+  it does nothing.
+
+
+    http://127.0.0.1:8081/start/chan1
+
+  If the "chan1" channel is hibernating, it restarts it. If it's
+  already running, it does nothing.
+
+
     http://127.0.0.1:8081/status
 
   Return current channels status. The status looks like this:
 
 # Status   DestAddr             ConnTime  ReadBytes ChanName           ChanSource                                                       ProxyStatus
 CONN_OK    239.78.78.78:5000         123     148708 chan1              http://example.com:8080/stb/chan1.mpg                            Synced
-CONN_ERROR 239.79.79.79:5000          60      65800 chan2              http://ux.iptv.bg:8080/stb/chan2.mpg                             Synced
-CONN_ERROR 239.80.80.80:5000           0          0 chan3              udp://239.1.2.3:5000/                                            Connected
+HIBERNATE  239.79.79.79:5000           0          0 chan2              http://ux.iptv.bg:8080/stb/chan2.mpg                             Initialized
+CONN_ERROR 239.80.80.80:5000          60      65800 chan3              udp://239.1.2.3:5000/                                            Connected
 
-  "Status" - current channel status which can be CONN_OK or CONN_ERROR
+  "Status" - current channel status which can be CONN_OK or CONN_ERROR or HIBERNATE
 
     CONN_ERROR - Means that the source of the channel is currently
                  not connected or bytes read are at least 1316 or
@@ -43,10 +55,13 @@ CONN_ERROR 239.80.80.80:5000           0          0 chan3              udp://239
 
   "ProxyStatus" - Last connection status
 
+    Initialized
     Connected
     Working
+    Hibernated
 
     Reconnecting
+    Hibernating
 
     Dying
     Forced reconnect

--- a/config.h
+++ b/config.h
@@ -56,6 +56,7 @@ typedef struct {
 	int reconnect:1,		/* Set to 1 to force proxy reconnect */
 	    connected:1,		/* It's set to 1 when proxy is connected and serving clients */
 	    dienow:1,			/* Stop serving clients and exit now */
+	    hibernate:1,		/* Sleep channel (while nobody uses him) */
 	    freechannel:1;		/* Free channel data on object free (this is used in chanconf) */
 	int cookie;				/* Used in chanconf to determine if the restreamer is alrady checked */
 	pthread_t thread;

--- a/web_pages.h
+++ b/web_pages.h
@@ -23,5 +23,7 @@ void cmd_status(int clientsock);
 void cmd_getconfig(int clientsock);
 void cmd_reconnect(int clientsock);
 void cmd_reload(int clientsock);
+void cmd_start(int clientsock, const char *uri);
+void cmd_stop(int clientsock, const char *uri);
 
 #endif

--- a/web_server.c
+++ b/web_server.c
@@ -136,6 +136,10 @@ void *process_web_request(void *in_req) {
 		cmd_reload(clientsock);
 	} else if (strstr(path,"status")==path) {
 		cmd_status(clientsock);
+	} else if (strstr(path,"start")==path) {
+		cmd_start(clientsock,path);
+	} else if (strstr(path,"stop")==path) {
+		cmd_stop(clientsock,path);
 	} else {
 		send_404_not_found(clientsock);
 	}


### PR DESCRIPTION
Channels can now be paused/restarted. A new API for the webserver provides the "start"/"stop" commands for a channel. In addition, a new command line parameter "-I" starts all channels in hibernation.